### PR TITLE
allow more than 1 hub to be sent

### DIFF
--- a/examples/deploy_fw_with_virtual_hub/main.tf
+++ b/examples/deploy_fw_with_virtual_hub/main.tf
@@ -60,10 +60,12 @@ module "firewall" {
   firewall_sku_tier   = "Standard"
   firewall_sku_name   = "AZFW_Hub"
   firewall_zones      = ["1", "2", "3"]
-  firewall_virtual_hub = {
-    virtual_hub_id  = azurerm_virtual_hub.vhub.id
-    public_ip_count = 4
-  }
+  firewall_virtual_hub = [
+    {
+      virtual_hub_id  = azurerm_virtual_hub.vhub.id
+      public_ip_count = 4
+    }
+  ]
   firewall_policy_id = module.fw_policy.resource.id
 }
 

--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ resource "azurerm_firewall" "this" {
     }
   }
   dynamic "virtual_hub" {
-    for_each = var.firewall_virtual_hub == null ? [] : [var.firewall_virtual_hub]
+    for_each = var.firewall_virtual_hub == null ? [] : var.firewall_virtual_hub
 
     content {
       virtual_hub_id  = virtual_hub.value.virtual_hub_id

--- a/variables.tf
+++ b/variables.tf
@@ -140,10 +140,10 @@ EOT
 }
 
 variable "firewall_virtual_hub" {
-  type = object({
+  type = list(object({
     public_ip_count = optional(number)
     virtual_hub_id  = string
-  })
+  }))
   default     = null
   description = <<-EOT
  - `public_ip_count` - (Optional) Specifies the number of public IPs to assign to the Firewall. Defaults to `1`.


### PR DESCRIPTION
## Description

At the moment only 1 virtual hub can be declared in the module

## Type of Change


- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [X] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [X] Update to documentation

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks
